### PR TITLE
refactor: standardize FoodTruck interface and fix type inconsistencies

### DIFF
--- a/src/components/FoodTruckFinder/FoodTruckFinder.spec.tsx
+++ b/src/components/FoodTruckFinder/FoodTruckFinder.spec.tsx
@@ -3,7 +3,7 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { FoodTruckFinder } from "./FoodTruckFinder";
 import { useFoodTruckFinder } from "@/hooks/useFoodTruckFinder";
-import type { FoodTruck } from "./FoodTruckFinder.types";
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 
 jest.mock("@/hooks/useFoodTruckFinder", () => ({
   useFoodTruckFinder: jest.fn(),
@@ -12,17 +12,19 @@ jest.mock("@/hooks/useFoodTruckFinder", () => ({
 const mockTrucks: FoodTruck[] = [
   {
     applicant: "Truck A",
-    fooditems: "tacos, burritos",
+    foodItems: "tacos, burritos",
     latitude: 37.7749,
     longitude: -122.4194,
-    locationdescription: "123 Main St",
+    description: "123 Main St",
+    address: "123 Main St",
   },
   {
     applicant: "Truck B",
-    fooditems: "burgers, fries",
+    foodItems: "burgers, fries",
     latitude: 37.7749,
     longitude: -122.4194,
-    locationdescription: "456 Oak St",
+    description: "456 Oak St",
+    address: "456 Oak St",
   },
 ];
 

--- a/src/components/FoodTruckFinder/FoodTruckFinder.tsx
+++ b/src/components/FoodTruckFinder/FoodTruckFinder.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
-import type { FoodTruck } from "./FoodTruckFinder.types";
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 import { useFoodTruckFinder } from "@/hooks/useFoodTruckFinder";
 import { FoodTruckList } from "@/components/FoodTruckList";
 import { Slider } from "@/components/ui/Slider";
@@ -64,7 +64,7 @@ export const FoodTruckFinder = () => {
     const normalizedSearchTerm = foodItemSearchTerm.toLowerCase();
     setFilteredFoodTrucks(
       trucks.filter((truck) =>
-        (truck.fooditems || "").toLowerCase().includes(normalizedSearchTerm)
+        (truck.foodItems || "").toLowerCase().includes(normalizedSearchTerm)
       )
     );
   }, [foodItemSearchTerm, trucks]);

--- a/src/components/FoodTruckFinder/FoodTruckFinder.types.ts
+++ b/src/components/FoodTruckFinder/FoodTruckFinder.types.ts
@@ -1,7 +1,0 @@
-export interface FoodTruck {
-  applicant: string;
-  locationdescription: string;
-  latitude: number;
-  longitude: number;
-  fooditems?: string;
-}

--- a/src/components/FoodTruckList/FoodTruckList.spec.tsx
+++ b/src/components/FoodTruckList/FoodTruckList.spec.tsx
@@ -3,20 +3,22 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { FoodTruckList } from "./FoodTruckList";
-import type { FoodTruck } from "./FoodTruckList.types";
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 
 const mockTrucks: FoodTruck[] = [
   {
     applicant: "Truck A",
-    locationdescription: "123 Main St",
-    fooditems: "tacos, burritos",
+    description: "123 Main St",
+    address: "123 Main St",
+    foodItems: "tacos, burritos",
     latitude: 37.7749,
     longitude: -122.4194,
   },
   {
     applicant: "Truck B",
-    locationdescription: "456 Oak St", 
-    fooditems: "burgers, fries",
+    description: "456 Oak St", 
+    address: "456 Oak St",
+    foodItems: "burgers, fries",
     latitude: 37.7749,
     longitude: -122.4194,
   },

--- a/src/components/FoodTruckList/FoodTruckList.tsx
+++ b/src/components/FoodTruckList/FoodTruckList.tsx
@@ -1,5 +1,6 @@
 import { useRef, useEffect } from "react";
-import type { FoodTruckListProps, FoodTruck } from "./FoodTruckList.types";
+import type { FoodTruckListProps } from "./FoodTruckList.types";
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 import { FoodTruckListSkeleton } from "./FoodTruckList.skeleton";
 
 export const FoodTruckList = ({ trucks, loading, selectedTruck, onTruckSelect }: FoodTruckListProps) => {
@@ -57,9 +58,9 @@ export const FoodTruckList = ({ trucks, loading, selectedTruck, onTruckSelect }:
           onClick={() => handleTruckClick(truck)}
         >
           <h2 className="text-lg font-semibold">{truck.applicant}</h2>
-          <p className="text-sm text-gray-600">{truck.locationdescription}</p>
-          {truck.fooditems && (
-            <p className="mt-2 text-sm italic text-gray-500">{truck.fooditems}</p>
+          <p className="text-sm text-gray-600">{truck.address}</p>
+          {truck.foodItems && (
+            <p className="mt-2 text-sm italic text-gray-500">{truck.foodItems}</p>
           )}
         </li>
       ))}

--- a/src/components/FoodTruckList/FoodTruckList.types.ts
+++ b/src/components/FoodTruckList/FoodTruckList.types.ts
@@ -1,10 +1,4 @@
-export interface FoodTruck {
-  applicant: string;
-  locationdescription: string;
-  latitude: number;
-  longitude: number;
-  fooditems?: string;
-}
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 
 export interface FoodTruckListProps {
   trucks: FoodTruck[];

--- a/src/components/FoodTruckMap/FoodTruckMap.spec.tsx
+++ b/src/components/FoodTruckMap/FoodTruckMap.spec.tsx
@@ -3,7 +3,7 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { FoodTruckMap } from "./FoodTruckMap";
-import type { FoodTruck } from "../FoodTruckList/FoodTruckList.types";
+import type { FoodTruck } from "@/utils/foodTruckLocator";
 import type { Coordinates } from "./FoodTruckMap.types";
 
 // Mock config state
@@ -31,10 +31,11 @@ jest.mock("@vis.gl/react-google-maps", () => ({
 const mockTrucks: FoodTruck[] = [
   {
     applicant: "Truck A",
-    fooditems: "tacos, burritos",
+    foodItems: "tacos, burritos",
     latitude: 37.7749,
     longitude: -122.4194,
-    locationdescription: "123 Main St",
+    description: "123 Main St",
+    address: "123 Main St",
   },
 ];
 

--- a/src/components/FoodTruckMap/FoodTruckMap.tsx
+++ b/src/components/FoodTruckMap/FoodTruckMap.tsx
@@ -61,7 +61,7 @@ export const FoodTruckMap = ({ trucks, userLocation, selectedTruck, onTruckSelec
             <AdvancedMarker
               key={`${t.applicant}-${idx}`}
               position={{ lat: t.latitude, lng: t.longitude }}
-              title={`${t.applicant} — ${t.locationdescription}`}
+              title={`${t.applicant} — ${t.description}`}
               onClick={() => onTruckSelect(t)}
             >
               <Pin background="#dc2626" glyphColor="#ffffff" borderColor="#dc2626" />
@@ -75,10 +75,10 @@ export const FoodTruckMap = ({ trucks, userLocation, selectedTruck, onTruckSelec
               headerContent={<div className="font-semibold text-lg">{selectedTruck.applicant}</div>}
             >
               <div className="max-w-[240px] text-black">
-                <div className="text-xs">{selectedTruck.locationdescription}</div>
-                {selectedTruck.fooditems && (
+                <div className="text-xs">{selectedTruck.address}</div>
+                {selectedTruck.foodItems && (
                   <div className="text-xs italic mt-1 whitespace-pre-wrap break-words">
-                    {selectedTruck.fooditems}
+                    {selectedTruck.foodItems}
                   </div>
                 )}
               </div>

--- a/src/components/FoodTruckMap/FoodTruckMap.types.ts
+++ b/src/components/FoodTruckMap/FoodTruckMap.types.ts
@@ -1,17 +1,13 @@
+import type { FoodTruck } from "@/utils/foodTruckLocator";
+
 export interface Coordinates {
   latitude: number;
   longitude: number;
 }
 
-export interface MapTruckMarker extends Coordinates {
-  applicant: string;
-  locationdescription: string;
-  fooditems?: string;
-}
-
 export interface MapProps {
-  trucks: MapTruckMarker[];
+  trucks: FoodTruck[];
   userLocation: Coordinates;
-  selectedTruck: MapTruckMarker | null;
-  onTruckSelect: (truck: MapTruckMarker | null) => void;
+  selectedTruck: FoodTruck | null;
+  onTruckSelect: (truck: FoodTruck | null) => void;
 }

--- a/src/hooks/useFoodTruckFinder/useFoodTruckFinder.ts
+++ b/src/hooks/useFoodTruckFinder/useFoodTruckFinder.ts
@@ -1,8 +1,7 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import type { FoodTruck, Coordinates } from "./useFoodTruckFinder.types";
-import { fetchNearbyTrucks } from "@/utils/foodTruckLocator";
+import { fetchNearbyTrucks, type FoodTruck, type Coordinates } from "@/utils/foodTruckLocator";
 
 export const useFoodTruckFinder = () => {
   const [trucks, setTrucks] = useState<FoodTruck[]>([]);

--- a/src/hooks/useFoodTruckFinder/useFoodTruckFinder.types.ts
+++ b/src/hooks/useFoodTruckFinder/useFoodTruckFinder.types.ts
@@ -1,11 +1,3 @@
-export interface FoodTruck {
-  applicant: string;
-  locationdescription: string;
-  latitude: number;
-  longitude: number;
-  fooditems?: string;
-}
-
 export interface Coordinates {
   latitude: number;
   longitude: number;

--- a/src/utils/foodTruckLocator/foodTruckLocator.spec.ts
+++ b/src/utils/foodTruckLocator/foodTruckLocator.spec.ts
@@ -24,6 +24,7 @@ describe('foodTruckLocator', () => {
       {
         applicant: 'Taco Truck 1',
         locationdescription: '123 Main St',
+        address: '123 Main St',
         latitude: '37.7749',
         longitude: '-122.4194',
         fooditems: 'Tacos, Burritos'
@@ -31,6 +32,7 @@ describe('foodTruckLocator', () => {
       {
         applicant: 'Burger Truck 2',
         locationdescription: '456 Oak Ave',
+        address: '456 Oak Ave',
         latitude: '37.7849',
         longitude: '-122.4094',
         fooditems: 'Burgers, Fries'
@@ -38,6 +40,7 @@ describe('foodTruckLocator', () => {
       {
         applicant: 'Invalid Truck',
         locationdescription: 'Invalid Location',
+        address: 'Invalid Location',
         latitude: 'invalid',
         longitude: 'invalid',
         fooditems: 'Invalid Food'
@@ -47,17 +50,19 @@ describe('foodTruckLocator', () => {
     const mockParsedTrucks: FoodTruck[] = [
       {
         applicant: 'Taco Truck 1',
-        locationdescription: '123 Main St',
+        description: '123 Main St',
+        address: '123 Main St',
         latitude: 37.7749,
         longitude: -122.4194,
-        fooditems: 'Tacos, Burritos'
+        foodItems: 'Tacos, Burritos'
       },
       {
         applicant: 'Burger Truck 2',
-        locationdescription: '456 Oak Ave',
+        description: '456 Oak Ave',
+        address: '456 Oak Ave',
         latitude: 37.7849,
         longitude: -122.4094,
-        fooditems: 'Burgers, Fries'
+        foodItems: 'Burgers, Fries'
       }
     ];
 
@@ -197,6 +202,7 @@ describe('foodTruckLocator', () => {
         {
           applicant: 'Invalid Truck 1',
           locationdescription: 'Invalid Location 1',
+          address: 'Invalid Location 1',
           latitude: 'invalid',
           longitude: 'invalid',
           fooditems: 'Invalid Food 1'
@@ -204,6 +210,7 @@ describe('foodTruckLocator', () => {
         {
           applicant: 'Invalid Truck 2',
           locationdescription: 'Invalid Location 2',
+          address: 'Invalid Location 2',
           latitude: 'NaN',
           longitude: 'Infinity',
           fooditems: 'Invalid Food 2'

--- a/src/utils/foodTruckLocator/foodTruckLocator.ts
+++ b/src/utils/foodTruckLocator/foodTruckLocator.ts
@@ -16,10 +16,11 @@ const parseRawFoodTruck = (rawTruckData: RawFoodTruck): FoodTruck | null => {
 
   return {
     applicant: rawTruckData.applicant,
-    locationdescription: rawTruckData.locationdescription,
+    description: rawTruckData.locationdescription,
+    address: rawTruckData.address,
     latitude,
     longitude,
-    fooditems: rawTruckData.fooditems,
+    foodItems: rawTruckData.fooditems,
   };
 };
 

--- a/src/utils/foodTruckLocator/foodTruckLocator.types.ts
+++ b/src/utils/foodTruckLocator/foodTruckLocator.types.ts
@@ -1,14 +1,16 @@
 export interface FoodTruck {
   applicant: string;
-  locationdescription: string;
+  description: string;
+  address: string;
   latitude: number;
   longitude: number;
-  fooditems?: string;
+  foodItems?: string;
 }
 
 export interface RawFoodTruck {
   applicant: string;
   locationdescription: string;
+  address: string;
   latitude: string;
   longitude: string;
   fooditems?: string;

--- a/src/utils/foodTruckLocator/index.ts
+++ b/src/utils/foodTruckLocator/index.ts
@@ -1,1 +1,2 @@
 export { fetchNearbyTrucks } from "./foodTruckLocator";
+export type { FoodTruck, RawFoodTruck, Coordinates } from "./foodTruckLocator.types";


### PR DESCRIPTION
refactor: standardize FoodTruck interface and fix type inconsistencies

- Consolidate FoodTruck type definition in @/utils/foodTruckLocator
- Update property names: locationdescription → description, fooditems → foodItems
- Add required address property to FoodTruck and RawFoodTruck interfaces
- Remove duplicate type definitions from component files